### PR TITLE
Change to using BufferedOutput parent

### DIFF
--- a/lib/fluent/plugin/out_graphite.rb
+++ b/lib/fluent/plugin/out_graphite.rb
@@ -1,6 +1,6 @@
 require 'fluent/mixin/rewrite_tag_name'
 
-class Fluent::GraphiteOutput < Fluent::Output
+class Fluent::GraphiteOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('graphite', self)
 
   include Fluent::HandleTagNameMixin


### PR DESCRIPTION
This allows td-agent to buffer metrics if there is a temporary network failure.
