### PR TITLE
Add a missing tets-unit dependency for development and testing

### DIFF
--- a/fluent-plugin-graphite.gemspec
+++ b/fluent-plugin-graphite.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'fluent-mixin-rewrite-tag-name'
   gem.add_runtime_dependency 'graphite-api'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'test-unit', '~> 3.2.0'
 end


### PR DESCRIPTION
Since Ruby 2.1, 'test/unit' had been caused `LoadError`.
So, we should depend `test-unit` gem explicitly.