### PR TITLE
Support tcp protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ message: `metrics { "f1":"100", "f2":"200", "f3":"300" }`
     type graphite
     host localhost
     port 2003
+    protocol udp
     tag_for prefix
     name_keys f1,f3
   </match>
@@ -52,6 +53,7 @@ message: `metrics { "f1":"100", "f2":"200", "f3":"300" }`
     type graphite
     host localhost
     port 2003
+    protocol udp
     tag_for prefix
     name_key_pattern f\d
   </match>
@@ -74,6 +76,7 @@ message: `metrics { "f1":"100", "f2":"200", "f3":"300" }`
     type graphite
     host localhost
     port 2003
+    protocol udp
     tag_for suffix
     name_keys f1,f2
   </match>
@@ -95,6 +98,7 @@ message: `metrics { "f1":"100", "f2":"200", "f3":"300" }`
     type graphite
     host localhost
     port 2003
+    protocol udp
     tag_for ignore
     name_keys f1,f2
   </match>
@@ -116,6 +120,10 @@ message: `metrics { "f1":"100", "f2":"200", "f3":"300" }`
 ###### port
 - Default is `2003`.
 - listening port of carbon-cache.
+
+###### protocol
+- Default is `udp`
+- socket protocol such as `tcp`, `udp`.
 
 ###### tag_for
 - Default is `prefix`.

--- a/lib/fluent/plugin/out_graphite.rb
+++ b/lib/fluent/plugin/out_graphite.rb
@@ -8,6 +8,7 @@ class Fluent::GraphiteOutput < Fluent::Output
 
   config_param :host, :string
   config_param :port, :integer, default: 2003
+  config_param :protocol, :string, default: 'udp'
   config_param :tag_for, :string, default: 'prefix'
   config_param :name_keys, :string, default: nil
   config_param :name_key_pattern, :string, default: nil
@@ -110,6 +111,6 @@ class Fluent::GraphiteOutput < Fluent::Output
   end
   
   def connect_client!
-    @client = GraphiteAPI.new(graphite: "#{@host}:#{@port}")
+    @client = GraphiteAPI.new(graphite: "#{@protocol}://#{@host}:#{@port}")
   end
 end

--- a/test/plugin/test_out_graphite.rb
+++ b/test/plugin/test_out_graphite.rb
@@ -2,37 +2,44 @@ require 'helper'
 
 class GraphiteOutputTest < Test::Unit::TestCase
   TCP_PORT = 42003
+  PROTOCOL = "tcp"
   CONFIG_NAME_KEY_PATTERN = %[
     host localhost
     port #{TCP_PORT}
+    protocol #{PROTOCOL}
     name_key_pattern ^((?!hostname).)*$
   ]
   CONFIG_NAME_KEYS = %[
     host localhost
     port #{TCP_PORT}
+    protocol #{PROTOCOL}
     name_keys dstat.total cpu usage.usr,dstat.total cpu usage.sys,dstat.total cpu usage.idl
   ]
   CONFIG_TAG_FOR_IGNORE = %[
     host localhost
     port #{TCP_PORT}
+    protocol #{PROTOCOL}
     name_keys dstat.total cpu usage.usr,dstat.total cpu usage.sys,dstat.total cpu usage.idl
     tag_for ignore
   ]
   CONFIG_TAG_FOR_SUFFIX = %[
     host localhost
     port #{TCP_PORT}
+    protocol #{PROTOCOL}
     name_keys dstat.total cpu usage.usr,dstat.total cpu usage.sys,dstat.total cpu usage.idl
     tag_for suffix
   ]
   CONFIG_INVALID_TAG_FOR = %[
     host localhost
     port #{TCP_PORT}
+    protocol #{PROTOCOL}
     name_key_pattern ^((?!hostname).)*$
     tag_for invalid
   ]
   CONFIG_SPECIFY_BOTH_NAME_KEYS_AND_NAME_KEY_PATTERN = %[
     host localhost
     port #{TCP_PORT}
+    protocol #{PROTOCOL}
     name_keys dstat.total cpu usage.usr,dstat.total cpu usage.sys,dstat.total cpu usage.idl
     name_key_pattern ^((?!hostname).)*$
   ]
@@ -54,6 +61,7 @@ class GraphiteOutputTest < Test::Unit::TestCase
     d = create_driver
     assert_equal d.instance.host, 'localhost'
     assert_equal d.instance.port, TCP_PORT
+    assert_equal d.instance.protocol, PROTOCOL
     assert_equal d.instance.tag_for, 'prefix'
     assert_equal d.instance.name_keys, nil
     assert_equal d.instance.name_key_pattern, /^((?!hostname).)*$/
@@ -61,6 +69,7 @@ class GraphiteOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG_NAME_KEYS)
     assert_equal d.instance.host, 'localhost'
     assert_equal d.instance.port, TCP_PORT
+    assert_equal d.instance.protocol, PROTOCOL
     assert_equal d.instance.tag_for, 'prefix'
     assert_equal d.instance.name_keys, ['dstat.total cpu usage.usr', 'dstat.total cpu usage.sys', 'dstat.total cpu usage.idl']
     assert_equal d.instance.name_key_pattern, nil
@@ -68,6 +77,7 @@ class GraphiteOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG_TAG_FOR_IGNORE)
     assert_equal d.instance.host, 'localhost'
     assert_equal d.instance.port, TCP_PORT
+    assert_equal d.instance.protocol, PROTOCOL
     assert_equal d.instance.tag_for, 'ignore'
     assert_equal d.instance.name_keys, ['dstat.total cpu usage.usr', 'dstat.total cpu usage.sys', 'dstat.total cpu usage.idl']
     assert_equal d.instance.name_key_pattern, nil
@@ -75,6 +85,7 @@ class GraphiteOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG_TAG_FOR_SUFFIX)
     assert_equal d.instance.host, 'localhost'
     assert_equal d.instance.port, TCP_PORT
+    assert_equal d.instance.protocol, PROTOCOL
     assert_equal d.instance.tag_for, 'suffix'
     assert_equal d.instance.name_keys, ['dstat.total cpu usage.usr', 'dstat.total cpu usage.sys', 'dstat.total cpu usage.idl']
     assert_equal d.instance.name_key_pattern, nil


### PR DESCRIPTION
`graphite-api` library selects udp protocol as default.

I added `protocol` option for supporting `tcp` protocol and changed doc & test.

